### PR TITLE
Sig-Network e2e test changes for s390x

### DIFF
--- a/tests/libnet/hotplug.go
+++ b/tests/libnet/hotplug.go
@@ -35,9 +35,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/libnode"
 )
 
 func VerifyDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, queueCount int32) *v1.VirtualMachineInstance {
@@ -115,7 +114,7 @@ func cleanMACAndIPAddressesFromStatus(status []v1.VirtualMachineInstanceNetworkI
 	for i := range status {
 		status[i].MAC = ""
 		//For s390x, as ipv6.method=auto by default, IP & IPs has value, so setting to zero-value like MAC.
-		if checks.IsS390X(testsuite.Arch) {
+		if libnode.GetArch() == "s390x" {
 			status[i].IP = ""
 			status[i].IPs = nil
 		}

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -70,7 +70,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			)
 			passtIface := libvmi.InterfaceWithPasstBindingPlugin()
 			passtIface.MacAddress = macAddress
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(passtIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -82,7 +82,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 
 			vmi = libwait.WaitUntilVMIReady(
 				vmi,
-				console.LoginToAlpine,
+				console.LoginToFedora,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
 			)
@@ -124,7 +124,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			macvtapIface := libvmi.InterfaceWithBindingPlugin(
 				ifaceName, v1.PluginBinding{Name: macvtapBindingName},
 			)
-			vmi = libvmifact.NewAlpineWithTestTooling(
+			vmi = libvmifact.NewFedora(
 				libvmi.WithInterface(
 					*libvmi.InterfaceWithMac(&macvtapIface, chosenMAC)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, macvtapNetworkName)))
@@ -133,7 +133,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			Expect(err).NotTo(HaveOccurred())
 			vmi = libwait.WaitUntilVMIReady(
 				vmi,
-				console.LoginToAlpine)
+				console.LoginToFedora)
 
 			Expect(vmi.Status.Interfaces).To(HaveLen(1), "should have a single interface")
 			Expect(vmi.Status.Interfaces[0].MAC).To(Equal(chosenMAC), "the expected MAC address should be set in the VMI")
@@ -157,14 +157,14 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			primaryIface := libvmi.InterfaceWithBindingPlugin(
 				networkName, v1.PluginBinding{Name: bindingName},
 			)
-			vmi = libvmifact.NewAlpineWithTestTooling(
+			vmi = libvmifact.NewFedora(
 				libvmi.WithInterface(primaryIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 
 			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine, libwait.WithTimeout(30))
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora, libwait.WithTimeout(30))
 
 			Expect(vmi.Status.Interfaces).To(HaveLen(1))
 			Expect(vmi.Status.Interfaces[0].Name).To(Equal(primaryIface.Name))
@@ -212,7 +212,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
 			}
-			serverVMI := libvmifact.NewAlpineWithTestTooling(opts...)
+			serverVMI := libvmifact.NewFedora(opts...)
 
 			primaryIface.MacAddress = "de:ad:00:00:be:aa"
 			opts = []libvmi.Option{
@@ -220,7 +220,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
 			}
-			clientVMI := libvmifact.NewAlpineWithTestTooling(opts...)
+			clientVMI := libvmifact.NewFedora(opts...)
 
 			ns := testsuite.GetTestNamespace(nil)
 			serverVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Create(context.Background(), serverVMI, metav1.CreateOptions{})
@@ -228,8 +228,8 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			clientVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
-			clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToAlpine)
+			serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
+			clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
 
 			Expect(libnet.AddIPAddress(serverVMI, guestIfaceName, serverCIDR)).To(Succeed())
 			Expect(libnet.AddIPAddress(clientVMI, guestIfaceName, clientCIDR)).To(Succeed())

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -92,8 +92,8 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),
 			libvmi.WithNodeAffinityFor(nodeName),
 		}
-		serverVMI := libvmifact.NewAlpineWithTestTooling(opts...)
-		clientVMI := libvmifact.NewAlpineWithTestTooling(opts...)
+		serverVMI := libvmifact.NewFedora(opts...)
+		clientVMI := libvmifact.NewFedora(opts...)
 
 		var err error
 		ns := testsuite.GetTestNamespace(nil)
@@ -102,8 +102,8 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 		clientVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
-		clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToAlpine)
+		serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
+		clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
 
 		Expect(libnet.AddIPAddress(serverVMI, guestIfaceName, serverCIDR)).To(Succeed())
 		Expect(libnet.AddIPAddress(clientVMI, guestIfaceName, clientCIDR)).To(Succeed())
@@ -115,7 +115,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 		var clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			clientVMI = libvmifact.NewAlpineWithTestTooling(
+			clientVMI = libvmifact.NewFedora(
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(
 					libvmi.InterfaceWithMacvtapBindingPlugin("test"), clientMAC)),
 				libvmi.WithNetwork(libvmi.MultusNetwork("test", macvtapNetworkName)),
@@ -123,7 +123,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 			var err error
 			clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), "should create VMI successfully")
-			clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToAlpine)
+			clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
 		})
 
 		It("should be successful when the VMI MAC address is defined in its spec", func() {

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -90,7 +90,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		passtIface.Ports = []v1.Port{{Port: 1234, Protocol: "TCP"}}
 		passtIface.MacAddress = testMACAddr
 		passtIface.PciAddress = testPCIAddr
-		vmi := libvmifact.NewAlpineWithTestTooling(
+		vmi := libvmifact.NewFedora(
 			libvmi.WithInterface(passtIface),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
@@ -99,7 +99,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		Expect(err).ToNot(HaveOccurred())
 		vmi = libwait.WaitUntilVMIReady(
 			vmi,
-			console.LoginToAlpine,
+			console.LoginToFedora,
 			libwait.WithFailOnWarnings(false),
 			libwait.WithTimeout(180),
 		)
@@ -121,7 +121,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 
 			startServerVMI := func(ports []v1.Port) {
 				passtIface := libvmi.InterfaceWithPasstBindingPlugin(ports...)
-				serverVMI = libvmifact.NewAlpineWithTestTooling(
+				serverVMI = libvmifact.NewFedora(
 					libvmi.WithInterface(passtIface),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
@@ -130,7 +130,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 				Expect(err).ToNot(HaveOccurred())
 				serverVMI = libwait.WaitUntilVMIReady(
 					serverVMI,
-					console.LoginToAlpine,
+					console.LoginToFedora,
 					libwait.WithFailOnWarnings(false),
 					libwait.WithTimeout(180),
 				)
@@ -154,7 +154,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 				}
 
 				startClientVMI := func() {
-					clientVMI = libvmifact.NewAlpineWithTestTooling(
+					clientVMI = libvmifact.NewFedora(
 						libvmi.WithPasstInterfaceWithPort(),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
@@ -162,7 +162,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 					clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					clientVMI = libwait.WaitUntilVMIReady(clientVMI,
-						console.LoginToAlpine,
+						console.LoginToFedora,
 						libwait.WithFailOnWarnings(false),
 						libwait.WithTimeout(180),
 					)
@@ -177,7 +177,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 					startServerVMI(ports)
 
 					By("starting a TCP server")
-					vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
+					vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToFedora)
 
 					Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, ipFamily)).To(Succeed())
 
@@ -186,7 +186,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 						vmPort := int(ports[0].Port)
 						serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
 
-						vmnetserver.StartTCPServer(serverVMI, vmPort+1, console.LoginToAlpine)
+						vmnetserver.StartTCPServer(serverVMI, vmPort+1, console.LoginToFedora)
 
 						By("Connecting from the client VM to a port not specified on the VM spec")
 						Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, tcpPort+1), 30)).NotTo(Succeed())
@@ -237,7 +237,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 					By("Starting server VMI")
 					startServerVMI([]v1.Port{{Port: SERVER_PORT, Protocol: "UDP"}})
 					serverVMI = libwait.WaitUntilVMIReady(serverVMI,
-						console.LoginToAlpine,
+						console.LoginToFedora,
 						libwait.WithFailOnWarnings(false),
 						libwait.WithTimeout(180),
 					)
@@ -246,14 +246,14 @@ EOL`, inetSuffix, serverIP, serverPort)
 					vmnetserver.StartPythonUDPServer(serverVMI, SERVER_PORT, ipFamily)
 
 					By("Starting client VMI")
-					clientVMI = libvmifact.NewAlpineWithTestTooling(
+					clientVMI = libvmifact.NewFedora(
 						libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin()),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
 					clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					clientVMI = libwait.WaitUntilVMIReady(clientVMI,
-						console.LoginToAlpine,
+						console.LoginToFedora,
 						libwait.WithFailOnWarnings(false),
 						libwait.WithTimeout(180),
 					)
@@ -285,14 +285,14 @@ EOL`, inetSuffix, serverIP, serverPort)
 				dns = flags.ConnectivityCheckDNS
 			}
 
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vmi = libwait.WaitUntilVMIReady(vmi,
-				console.LoginToAlpine,
+				console.LoginToFedora,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
 			)
@@ -312,7 +312,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 				ipv6Address = flags.IPV6ConnectivityCheckAddress
 			}
 
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithAnnotation("kubevirt.io/libvirt-log-filters", "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"),
@@ -321,7 +321,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vmi = libwait.WaitUntilVMIReady(vmi,
-				console.LoginToAlpine,
+				console.LoginToFedora,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
 			)

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -61,7 +61,7 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 	})
 
 	It("VMI with SLIRP interface, custom mac and port is configured correctly", func() {
-		vmi := libvmifact.NewCirros(
+		vmi := libvmifact.NewAlpine(
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(v1.Interface{
 				Name:       v1.DefaultPodNetwork().Name,
@@ -78,7 +78,7 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 			libwait.WithTimeout(180),
 		)
 
-		generateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
+		generateHelloWorldServer(vmi, 80, "tcp", console.LoginToAlpine, true)
 
 		By("have containerPort in the pod manifest")
 		vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -71,7 +71,7 @@ var _ = Describe(SIG("bridge nic-hotplug", func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -82,7 +82,7 @@ var _ = Describe(SIG("bridge nic-hotplug", func() {
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			hotPluggedVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToAlpine(hotPluggedVMI)).To(Succeed())
+			Expect(console.LoginToFedora(hotPluggedVMI)).To(Succeed())
 
 			By("Creating a NAD")
 			netAttachDef := libnet.NewBridgeNetAttachDef(nadName, linuxBridgeName)
@@ -244,7 +244,7 @@ var _ = Describe(SIG("bridge nic-hotunplug", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("running a VM")
-			vmi = libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking(),
+			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking(),
 				libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeNetworkName1, nadName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeNetworkName2, nadName)),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeNetworkName1)),
@@ -255,7 +255,7 @@ var _ = Describe(SIG("bridge nic-hotunplug", func() {
 			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 		})
 
 		DescribeTable("hot-unplug network interface succeed", func(plugMethod hotplugMethod) {

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -64,7 +64,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -75,7 +75,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			hotPluggedVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToAlpine(hotPluggedVMI)).To(Succeed())
+			Expect(console.LoginToFedora(hotPluggedVMI)).To(Succeed())
 
 			By("Creating a NAD")
 			Expect(createSRIOVNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), nadName, sriovResourceName)).To(Succeed())

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -45,7 +45,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 		serverVMILabels = map[string]string{"type": "test"}
 	})
 
-	Context("when three alpine VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
+	Context("when three Fedora VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
 		var serverVMI, clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -391,19 +391,19 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
-	clientVMI := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+	clientVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 	var err error
 	clientVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToAlpine)
+	clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
 	return clientVMI, nil
 }
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
-	serverVMI := libvmifact.NewAlpineWithTestTooling(
+	serverVMI := libvmifact.NewFedora(
 		libnet.WithMasqueradeNetworking(
 			v1.Port{
 				Name:     "http80",
@@ -422,7 +422,7 @@ func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, server
 	if err != nil {
 		return nil, err
 	}
-	serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
+	serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
 
 	By("Start HTTP server at serverVMI on ports 80 and 81")
 	vmnetserver.HTTPServer.Start(serverVMI, 80)

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -72,8 +72,8 @@ var _ = Describe(SIG("Port-forward", func() {
 				Skip(skipIPv6Message)
 			}
 
-			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
+			vmi := createAlpineVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
+			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToAlpine)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -163,15 +163,15 @@ func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
 	return err
 }
 
-func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewCirros(
+func createAlpineVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewAlpine(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 	)
 
 	vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	return vmi
 }

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -284,7 +284,7 @@ func createReadyFedoraVMIWithReadinessProbe(probe *v1.Probe) *v1.VirtualMachineI
 }
 
 func createReadyFedoraVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewFedoralibnet.WithMasqueradeNetworking(), withLivelinessProbe(probe))
+	vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivelinessProbe(probe))
 
 	return libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -92,10 +92,10 @@ var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with readiness probe")
 
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyFedoraVMIWithReadinessProbereadinessProbe)
+				vmi = createReadyFedoraVMIWithReadinessProbe(readinessProbe)
 			} else if !isExecProbe(readinessProbe) {
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyFedoraVMIWithReadinessProbereadinessProbe)
+				vmi = createReadyFedoraVMIWithReadinessProbe(readinessProbe)
 
 				Expect(matcher.ThisVMI(vmi)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -92,10 +92,10 @@ var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with readiness probe")
 
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyAlpineVMIWithReadinessProbe(readinessProbe)
+				vmi = createReadyFedoraVMIWithReadinessProbereadinessProbe)
 			} else if !isExecProbe(readinessProbe) {
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyAlpineVMIWithReadinessProbe(readinessProbe)
+				vmi = createReadyFedoraVMIWithReadinessProbereadinessProbe)
 
 				Expect(matcher.ThisVMI(vmi)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
 
@@ -156,8 +156,8 @@ var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 			By("Checking that the VMI is consistently non-ready")
 			Consistently(matcher.ThisVMI(vmi), 30*time.Second, 100*time.Millisecond).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
 		},
-			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", createTCPProbe(period, initialSeconds, port), libvmifact.NewAlpine),
-			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", createHTTPProbe(period, initialSeconds, port), libvmifact.NewAlpine),
+			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", createTCPProbe(period, initialSeconds, port), libvmifact.NewFedora),
+			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", createHTTPProbe(period, initialSeconds, port), libvmifact.NewFedora),
 			Entry("[test_id:TODO]with working Exec probe and invalid command", createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmifact.NewFedora),
 			Entry("[test_id:TODO]with working Exec probe and infinitely running command", createExecProbe(period, initialSeconds, timeoutSeconds, "tail", "-f", "/dev/null"), libvmifact.NewFedora),
 		)
@@ -187,10 +187,10 @@ var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with liveness probe")
 
 				By(specifyingVMLivenessProbe)
-				vmi = createReadyAlpineVMIWithLivenessProbe(livenessProbe)
+				vmi = createReadyFedoraVMIWithLivenessProbe(livenessProbe)
 			} else if !isExecProbe(livenessProbe) {
 				By(specifyingVMLivenessProbe)
-				vmi = createReadyAlpineVMIWithLivenessProbe(livenessProbe)
+				vmi = createReadyFedoraVMIWithLivenessProbe(livenessProbe)
 
 				By("Starting the server inside the VMI")
 				serverStarter(vmi, livenessProbe, 1500)
@@ -248,8 +248,8 @@ var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 				return vmi.IsFinal()
 			}, 120, 1).Should(BeTrue())
 		},
-			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", createTCPProbe(period, initialSeconds, port), libvmifact.NewCirros),
-			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", createHTTPProbe(period, initialSeconds, port), libvmifact.NewCirros),
+			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", createTCPProbe(period, initialSeconds, port), libvmifact.NewFedora),
+			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", createHTTPProbe(period, initialSeconds, port), libvmifact.NewFedora),
 			Entry("[test_id:5880]with working Exec probe and invalid command", createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmifact.NewFedora),
 		)
 	})
@@ -278,13 +278,13 @@ func guestAgentOperation(vmi *v1.VirtualMachineInstance, startStopOperation stri
 	}, 120)
 }
 
-func createReadyAlpineVMIWithReadinessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking(), withReadinessProbe(probe))
+func createReadyFedoraVMIWithReadinessProbeprobe *v1.Probe) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewFedoralibnet.WithMasqueradeNetworking(), withReadinessProbe(probe))
 	return libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
-func createReadyAlpineVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking(), withLivelinessProbe(probe))
+func createReadyFedoraVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewFedoralibnet.WithMasqueradeNetworking(), withLivelinessProbe(probe))
 
 	return libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
@@ -341,9 +341,9 @@ func isHTTPProbe(probe v1.Probe) bool {
 
 func serverStarter(vmi *v1.VirtualMachineInstance, probe *v1.Probe, port int) {
 	if isHTTPProbe(*probe) {
-		vmnetserver.StartHTTPServer(vmi, port, console.LoginToAlpine)
+		vmnetserver.StartHTTPServer(vmi, port, console.LoginToFedora)
 	} else {
-		vmnetserver.StartTCPServer(vmi, port, console.LoginToAlpine)
+		vmnetserver.StartTCPServer(vmi, port, console.LoginToFedora)
 	}
 }
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -278,8 +278,8 @@ func guestAgentOperation(vmi *v1.VirtualMachineInstance, startStopOperation stri
 	}, 120)
 }
 
-func createReadyFedoraVMIWithReadinessProbeprobe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewFedoralibnet.WithMasqueradeNetworking(), withReadinessProbe(probe))
+func createReadyFedoraVMIWithReadinessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withReadinessProbe(probe))
 	return libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -68,7 +68,7 @@ var _ = Describe(SIG("Services", func() {
 		BeforeEach(func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 
-			inboundVMI = libvmifact.NewCirros(
+			inboundVMI = libvmifact.NewAlpine(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
@@ -79,8 +79,8 @@ var _ = Describe(SIG("Services", func() {
 			inboundVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), inboundVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
-			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToCirros)
+			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
+			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToAlpine)
 		})
 
 		Context("with a service matching the vmi exposed", func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -212,14 +212,14 @@ var istioTests = func(vmType VmType) {
 			BeforeEach(func() {
 				skipTestByVMType(vmType)
 
-				bastionVMI = libvmifact.NewCirros(
+				bastionVMI = libvmifact.NewAlpine(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 				)
 
 				bastionVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), bastionVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToCirros)
+				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToAlpine)
 			})
 			Context("With VMI having explicit ports specified", func() {
 				BeforeEach(func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -163,7 +163,7 @@ var istioTests = func(vmType VmType) {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Waiting for VMI to be ready")
-			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+			libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 		})
 		Describe("Live Migration", decorators.RequiresTwoSchedulableNodes, decorators.SigComputeMigrations, func() {
 			var sourcePodName string
@@ -212,14 +212,14 @@ var istioTests = func(vmType VmType) {
 			BeforeEach(func() {
 				skipTestByVMType(vmType)
 
-				bastionVMI = libvmifact.NewAlpine(
+				bastionVMI = libvmifact.NewFedora(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 				)
 
 				bastionVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), bastionVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToAlpine)
+				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToFedora)
 			})
 			Context("With VMI having explicit ports specified", func() {
 				BeforeEach(func() {
@@ -343,7 +343,7 @@ var istioTests = func(vmType VmType) {
 			BeforeEach(func() {
 				networkData := cloudinit.CreateDefaultCloudInitNetworkData()
 
-				serverVMI = libvmifact.NewAlpineWithTestTooling(
+				serverVMI = libvmifact.NewFedora(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 					libvmi.WithLabel("version", "v1"),
@@ -359,7 +359,7 @@ var istioTests = func(vmType VmType) {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Starting HTTP Server")
-				Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
+				Expect(console.LoginToFedora(serverVMI)).To(Succeed())
 				vmnetserver.StartPythonHTTPServer(serverVMI, vmiServerTestPort)
 
 				By("Creating Istio VirtualService")
@@ -514,7 +514,7 @@ const enablePasswordAuth = "#cloud-config\nssh_pwauth: true\n"
 
 func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 	networkData := cloudinit.CreateDefaultCloudInitNetworkData()
-	vmi := libvmifact.NewAlpineWithTestTooling(
+	vmi := libvmifact.NewFedora(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
@@ -528,7 +528,7 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 }
 
 func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewAlpineWithTestTooling(
+	vmi := libvmifact.NewFedora(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -93,7 +93,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 				}, 50, 5).Should(Equal(k8sv1.PodSucceeded))
 
 				By("starting another VMI on the same node, to verify kubelet is running again")
-				newVMI := libvmifact.NewCirros()
+				newVMI := libvmifact.NewAlpine()
 				newVMI.Spec.NodeSelector = map[string]string{k8sv1.LabelHostname: nodeName}
 				Eventually(func() error {
 					newVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(newVMI)).Create(context.Background(), newVMI, metav1.CreateOptions{})
@@ -111,7 +111,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 
 			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", decorators.Networking, func() {
 				libnet.SkipWhenClusterNotSupportIpv4()
-				bridgeVMI := libvmifact.NewCirros(
+				bridgeVMI := libvmifact.NewAlpine(
 					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
@@ -121,7 +121,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting the VirtualMachineInstance start")
-				bridgeVMI = libwait.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
+				bridgeVMI = libwait.WaitUntilVMIReady(bridgeVMI, console.LoginToAlpine)
 				verifyDummyNicForBridgeNetwork(bridgeVMI)
 
 				vmIP := libnet.GetVmiPrimaryIPByFamily(bridgeVMI, k8sv1.IPv4Protocol)

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -253,7 +253,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				const secondaryNetName = "ptp"
-				detachedVMI := libvmifact.NewCirros(
+				detachedVMI := libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -262,9 +262,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToCirros)
+				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToFedora)
 
-				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
+				cmdCheck := "sudo dhclient eth1 > /dev/null\n"
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: console.PromptExpression},

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -190,7 +190,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 	createVMIOnNode := func(interfaces []v1.Interface, networks []v1.Network) *v1.VirtualMachineInstance {
 		// Arbitrarily select one compute node in the cluster, on which it is possible to create a VMI
 		// (i.e. a schedulable node).
-		vmi := libvmifact.NewAlpine(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
+		vmi := libvmifact.NewFedora(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 		vmi.Spec.Domain.Devices.Interfaces = interfaces
 		vmi.Spec.Networks = networks
 		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -214,7 +214,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 			})
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmifact.NewAlpineWithTestTooling(
+				detachedVMI := libvmifact.NewFedora(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -226,14 +226,14 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToFedora)
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmifact.NewAlpineWithTestTooling(
+				detachedVMI := libvmifact.NewFedora(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -245,7 +245,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToFedora)
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
@@ -293,7 +293,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					),
 				)
 				Expect(err).NotTo(HaveOccurred())
-				detachedVMI := libvmifact.NewAlpineWithTestTooling(
+				detachedVMI := libvmifact.NewFedora(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -308,7 +308,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(detachedVMI, console.LoginToFedora)
 
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
@@ -355,7 +355,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				interfaces[0].MacAddress = customMacAddress
 
 				vmiOne := createVMIOnNode(interfaces, networks)
-				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
 
 				By("Configuring static IP address to ptp interface.")
 				Expect(libnet.AddIPAddress(vmiOne, "eth0", ptpSubnetIP1+ptpSubnetMask)).To(Succeed())
@@ -409,14 +409,14 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				vmiOne := createVMIOnNode(interfaces, networks)
 				vmiTwo := createVMIOnNode(interfaces, networks)
 
-				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
-				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
+				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
 
-				Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, staticIPVm1)).To(Succeed())
+				Expect(configureFedoraInterfaceIP(vmiOne, ifaceName, staticIPVm1)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 				Expect(libnet.InterfaceExists(vmiOne, ifaceName)).To(Succeed())
 
-				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
+				Expect(configureFedoraInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 				Expect(libnet.InterfaceExists(vmiTwo, ifaceName)).To(Succeed())
 				ipAddr := ""
@@ -512,7 +512,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 				vmiOne := createVMIOnNode(interfaces, networks)
 
-				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
 
 				updatedVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiOne)).Get(context.Background(), vmiOne.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -749,7 +749,7 @@ func changeInterfaceMACAddress(vmi *v1.VirtualMachineInstance, interfaceName, ne
 }
 
 // If staticIP is empty the interface would get a dynamic IP
-func configureAlpineInterfaceIP(vmi *v1.VirtualMachineInstance, ifaceName, staticIP string) error {
+func configureFedoraInterfaceIP(vmi *v1.VirtualMachineInstance, ifaceName, staticIP string) error {
 	if staticIP == "" {
 		return activateDHCPOnVMInterfaces(vmi, ifaceName)
 	}

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -82,8 +82,8 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 		Context("with a test outbound VMI", func() {
 			BeforeEach(func() {
-				inboundVMI = libvmifact.NewCirros()
-				outboundVMI = libvmifact.NewCirros()
+				inboundVMI = libvmifact.NewFedora()
+				outboundVMI = libvmifact.NewFedora()
 				inboundVMIWithPodNetworkSet = vmiWithPodNetworkSet()
 				inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
 
@@ -124,7 +124,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
 				By("checking eth0 MTU inside the VirtualMachineInstance")
-				Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
+				Expect(console.LoginToFedora(outboundVMI)).To(Succeed())
 
 				addrShow := "ip address show eth0\n"
 				Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
@@ -141,7 +141,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				// we transferred its IP address under DHCP server control, so the
 				// only thing we can validate is connectivity between VMIs
 				//
-				// NOTE: cirros ping doesn't support -M do that could be used to
+				// NOTE: fedora ping doesn't support -M do that could be used to
 				// validate end-to-end connectivity with Don't Fragment flag set
 				cmdCheck := fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
 				err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
@@ -168,11 +168,11 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 
 		It("clients should be able to reach VM workload, with propagated IP from a pod", func() {
-			inboundVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), libvmifact.NewCirros(), metav1.CreateOptions{})
+			inboundVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), libvmifact.NewAlpine(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
+			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
 			const testPort = 1500
-			vmnetserver.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
+			vmnetserver.StartTCPServer(inboundVMI, testPort, console.LoginToAlpine)
 
 			ip := inboundVMI.Status.Interfaces[0].IP
 
@@ -206,7 +206,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		It("[test_id:1770]should expose the right device type to the guest", func() {
 			By("checking the device vendor in /sys/class")
 			// Create a machine with e1000 interface model
-			// Use alpine because cirros dhcp client starts prematurely before link is ready
+			// Use alpine because alpine dhcp client starts prematurely before link is ready
 			e1000ModelIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 			e1000ModelIface.Model = "e1000"
 			e1000ModelIface.PciAddress = "0000:02:01.0"
@@ -351,7 +351,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 	Context("VirtualMachineInstance with custom dns", func() {
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
-			dnsVMI := libvmifact.NewCirros()
+			dnsVMI := libvmifact.NewFedora()
 
 			dnsVMI.Spec.DNSPolicy = "None"
 
@@ -365,7 +365,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			}
 			dnsVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(dnsVMI)).Create(context.Background(), dnsVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			dnsVMI = libwait.WaitUntilVMIReady(dnsVMI, console.LoginToCirros)
+			dnsVMI = libwait.WaitUntilVMIReady(dnsVMI, console.LoginToFedora)
 			const catResolvConf = "cat /etc/resolv.conf\n"
 			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
@@ -399,7 +399,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			if ipv4NetworkCIDR != "" {
 				net.NetworkSource.Pod.VMNetworkCIDR = ipv4NetworkCIDR
 			}
-			return libvmifact.NewCirros(
+			return libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 				libvmi.WithNetwork(net),
 			)
@@ -474,18 +474,18 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 					context.Background(), masqueradeVMI([]v1.Port{}, networkCIDR), metav1.CreateOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToCirros)
+				clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
 
 				serverVMI := masqueradeVMI(ports, networkCIDR)
 				serverVMI.Labels = map[string]string{"expose": "server"}
 				serverVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), serverVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToCirros)
+				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
 				Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
 				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 				By("starting a tcp server")
-				vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
+				vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToFedora)
 
 				if networkCIDR == "" {
 					networkCIDR = api.DefaultVMCIDR
@@ -518,7 +518,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 					context.Background(), masqueradeVMI([]v1.Port{}, ""), metav1.CreateOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 
 				By("Checking ping (IPv4)")
 				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
@@ -603,7 +603,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 				virtHandlerPod, err := getVirtHandlerPod()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -723,12 +723,12 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create another VMI")
-				anotherVmi = libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+				anotherVmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 				anotherVmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), anotherVmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for VMIs to be ready")
-				anotherVmi = libwait.WaitUntilVMIReady(anotherVmi, console.LoginToAlpine)
+				anotherVmi = libwait.WaitUntilVMIReady(anotherVmi, console.LoginToFedora)
 
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 			})
@@ -846,18 +846,18 @@ func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 	var err error
 	vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 	return vmi
 }
 
 func vmiWithPodNetworkSet() *v1.VirtualMachineInstance {
-	return libvmifact.NewCirros(
+	return libvmifact.NewFedora(
 		libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }
 
 func vmiWithCustomMacAddress(mac string) *v1.VirtualMachineInstance {
-	return libvmifact.NewCirros(
+	return libvmifact.NewFedora(
 		libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultBridgeNetworkInterface(), mac)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -367,6 +367,24 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			dnsVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(dnsVMI)).Create(context.Background(), dnsVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			dnsVMI = libwait.WaitUntilVMIReady(dnsVMI, console.LoginToFedora)
+
+			// Disable systemd-resolved
+			if checks.IsS390X(testsuite.Arch) {
+				err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
+					&expect.BSnd{S: "systemctl is-active systemd-resolved && sudo systemctl stop systemd-resolved || echo 'not running'\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "systemctl is-enabled systemd-resolved && sudo systemctl disable systemd-resolved || echo 'not enabled'\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "sudo rm -f /etc/resolv.conf\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "echo -e \"nameserver 8.8.8.8\\nnameserver 4.2.2.1\\nnameserver 1.1.1.1\\nsearch example.com\" | sudo tee /etc/resolv.conf\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "sudo systemctl restart NetworkManager\n"}, // Ensure DNS changes take effect
+					&expect.BExp{R: console.PromptExpression},
+				}, 30)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			const catResolvConf = "cat /etc/resolv.conf\n"
 			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -368,24 +368,24 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			dnsVMI = libwait.WaitUntilVMIReady(dnsVMI, console.LoginToFedora)
 
 			// Disable systemd-resolved
-			//if libnode.GetArch() == "s390x" {
-			//	err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
-			//		&expect.BSnd{S: "systemctl is-active systemd-resolved && sudo systemctl stop systemd-resolved || echo 'not running'\n"},
-			//		&expect.BExp{R: console.PromptExpression},
-			//		&expect.BSnd{S: "systemctl is-enabled systemd-resolved && sudo systemctl disable systemd-resolved || echo 'not enabled'\n"},
-			//		&expect.BExp{R: console.PromptExpression},
-			//		&expect.BSnd{S: "sudo rm -f /etc/resolv.conf\n"},
-			//		&expect.BExp{R: console.PromptExpression},
-			//		&expect.BSnd{S: "echo -e \"nameserver 8.8.8.8\\nnameserver 4.2.2.1\\nnameserver 1.1.1.1\\nsearch example.com\" | sudo tee /etc/resolv.conf\n"},
-			//		&expect.BExp{R: console.PromptExpression},
-			//		&expect.BSnd{S: "sudo systemctl restart NetworkManager\n"}, // Ensure DNS changes take effect
-			//		&expect.BExp{R: console.PromptExpression},
-			//	}, 30)
-			//	Expect(err).ToNot(HaveOccurred())
-			//}
+			if libnode.GetArch() == "s390x" {
+				err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
+					&expect.BSnd{S: "systemctl is-active systemd-resolved && sudo systemctl stop systemd-resolved || echo 'not running'\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "systemctl is-enabled systemd-resolved && sudo systemctl disable systemd-resolved || echo 'not enabled'\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "sudo rm -f /etc/resolv.conf\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "echo -e \"nameserver 8.8.8.8\\nnameserver 4.2.2.1\\nnameserver 1.1.1.1\\nsearch example.com\" | sudo tee /etc/resolv.conf\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "sudo systemctl restart NetworkManager\n"}, // Ensure DNS changes take effect
+					&expect.BExp{R: console.PromptExpression},
+				}, 30)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			// Since we are using Fedora image the dns config will be present in /etc/systemd/resolved.conf
-			const catResolvConf = "cat /etc/systemd/resolv.conf\n"
+			const catResolvConf = "cat /etc/resolv.conf\n"
 			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
@@ -401,7 +401,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				&expect.BExp{R: "nameserver 4.2.2.1"},
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "cat /etc/systemd/resolv.conf\n"},
+				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "nameserver 1.1.1.1"},
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -562,6 +563,12 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				// Docker network subnet cidr definition:
 				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
 				ipv6Address := "2001:db8:1::1"
+
+				// Use a different ipv6 address on s390x
+				if checks.IsS390X(testsuite.Arch) {
+					ipv6Address = "fd10:0:2::2"
+				}
+
 				if flags.IPV6ConnectivityCheckAddress != "" {
 					ipv6Address = flags.IPV6ConnectivityCheckAddress
 				}
@@ -623,8 +630,8 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 
 				By("Initiating DHCP client request after migration")
 
-				Expect(console.RunCommand(vmi, "sudo cirros-dhcpc down eth0\n", time.Second*time.Duration(15))).To(Succeed(), "failed to release dhcp client")
-				Expect(console.RunCommand(vmi, "sudo cirros-dhcpc up eth0\n", time.Second*time.Duration(15))).To(Succeed(), "failed to run dhcp client")
+				Expect(console.RunCommand(vmi, "sudo dhclient -r eth0\n", time.Second*time.Duration(15))).To(Succeed(), "failed to release dhcp client")
+				Expect(console.RunCommand(vmi, "sudo dhclient  eth0\n", time.Second*time.Duration(15))).To(Succeed(), "failed to run dhcp client")
 
 				Expect(ping(podIP)).To(Succeed())
 			},


### PR DESCRIPTION
What this PR does
This PR fixes the e2e tests for s390x Arch. The proposed changes in this PR will pass the e2e test for s390x arch which were failing before.

Fixes:
1. Fixed few of the tests by changing Cirros image to Fedora or Alpine as Cirros is not supported for s390x.
2. For few tests i have used Fedora instead of AlpineWithTestTooling as for s390x AlpineWithTestTooling is not supported and we have requested to build this image (https://github.com/alpinelinux/alpine-make-vm-image/issues/43).
3. For one of the test i have added ipv6 address for s390x as the existing one is not supported for us
4. For one of the test i have changed the DHCP client command as i was using Fedora instead of Cirros image as it is not supported for s390x
5. For one of the test ([test_id:1779]) related to configuring custom dns i have added code for s390x to disable systemd-resolved as it is responsible for dns resolutions. If it is running it might overwrite the custom dns entry applied.
6. For one of the test case related to bridge-nic-hot-plug i have set IP & IP's value to Zero. For s390x ipv6.method=auto by default, IP & IPs has value, so i have set it to zero-value like MAC.